### PR TITLE
Integrate CLI with Python service and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# TODO
+# StockLens
 
-// more soon
+StockLens is a small multi-language toolkit for retrieving and analysing
+stock market data.
+
+It consists of:
+
+* A **FastAPI** microservice that fetches live data from Yahoo Finance.
+* A **Go** command line interface built with Cobra that consumes the service.
+
+## Setup
+
+### Python service
+
+```
+cd python-service
+pip install -r requirements.txt
+uvicorn server:app --reload
+```
+
+The service listens on `http://localhost:8000` by default.
+
+### Go CLI
+
+```
+go run ./cli price AAPL
+```
+
+The CLI contacts the Python service using the environment variable
+`STOCKLENS_SERVICE_URL` (default `http://localhost:8000`).
+
+## Testing
+
+```
+pytest python-service
+go test ./...
+```
+
+## Future work
+
+* Enhance analysis metrics and incorporate additional data sources.
+* Improve error handling and add more extensive tests.
+

--- a/cli/cmd/analyze.go
+++ b/cli/cmd/analyze.go
@@ -6,19 +6,32 @@ package cmd
 import (
 	"fmt"
 
-
 	"github.com/spf13/cobra"
 )
+
+type analysisResponse struct {
+	Ticker string   `json:"ticker"`
+	Price  float64  `json:"price"`
+	PE     *float64 `json:"pe,omitempty"`
+}
 
 // analyzeCmd represents the analyze command
 var analyzeCmd = &cobra.Command{
 	Use:   "analyze [ticker]",
 	Short: "Analyze a stock by a ticker symbol",
-	Long: `Fetches stock data and calculates a valuation score.`,
+	Long:  `Fetches stock data and calculates a valuation score.`,
 	Args:  cobra.ExactArgs(1), // Requires exactly one argument
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ticker := args[0]
-		fmt.Printf("Analyzing stock: %s\n", ticker)
+		var resp analysisResponse
+		if err := fetchJSON(analyzeURL(ticker), &resp); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s price: %.2f\n", resp.Ticker, resp.Price)
+		if resp.PE != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "P/E: %.2f\n", *resp.PE)
+		}
+		return nil
 	},
 }
 

--- a/cli/cmd/analyze_test.go
+++ b/cli/cmd/analyze_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeCommand(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/analyze" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"ticker":"AAPL","price":123.45,"pe":20.0}`)
+	}))
+	defer ts.Close()
+
+	os.Setenv("STOCKLENS_SERVICE_URL", ts.URL)
+	defer os.Unsetenv("STOCKLENS_SERVICE_URL")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"analyze", "AAPL"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "P/E") {
+		t.Fatalf("expected output to contain analysis, got %s", out)
+	}
+}

--- a/cli/cmd/price.go
+++ b/cli/cmd/price.go
@@ -9,14 +9,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type priceResponse struct {
+	Ticker string  `json:"ticker"`
+	Price  float64 `json:"price"`
+}
+
 // priceCmd represents the price command
 var priceCmd = &cobra.Command{
-	Use:   "price",
+	Use:   "price [ticker]",
 	Short: "Returns the current price of the stock",
-	Long: `Returns the current price of the ticker symbol provided. 
-	Price is last known price during standard market hours`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("price called")
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ticker := args[0]
+		var resp priceResponse
+		if err := fetchJSON(priceURL(ticker), &resp); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s price: %.2f\n", resp.Ticker, resp.Price)
+		return nil
 	},
 }
 

--- a/cli/cmd/price_test.go
+++ b/cli/cmd/price_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Test that the price command calls the service and prints the price.
+func TestPriceCommand(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/price" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"ticker":"AAPL","price":123.45}`)
+	}))
+	defer ts.Close()
+
+	os.Setenv("STOCKLENS_SERVICE_URL", ts.URL)
+	defer os.Unsetenv("STOCKLENS_SERVICE_URL")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"price", "AAPL"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "123.45") {
+		t.Fatalf("expected output to contain price, got %s", out)
+	}
+}

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+func serviceBaseURL() string {
+	if v := os.Getenv("STOCKLENS_SERVICE_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:8000"
+}
+
+func fetchJSON(path string, out interface{}) error {
+	endpoint := fmt.Sprintf("%s%s", serviceBaseURL(), path)
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("service error: %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func priceURL(ticker string) string {
+	return fmt.Sprintf("/price?ticker=%s", url.QueryEscape(ticker))
+}
+
+func analyzeURL(ticker string) string {
+	return fmt.Sprintf("/analyze?ticker=%s", url.QueryEscape(ticker))
+}

--- a/python-service/fetch_data.py
+++ b/python-service/fetch_data.py
@@ -1,0 +1,57 @@
+"""Utility functions for retrieving stock data."""
+
+import logging
+from typing import Any, Dict, Optional
+
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+
+def _get_last_price(ticker: str) -> Optional[float]:
+    """Fetch the last traded price for ``ticker``.
+
+    Returns ``None`` if the price cannot be determined.
+    """
+
+    data = yf.Ticker(ticker)
+    try:
+        price = data.fast_info["last_price"]
+    except Exception:  # pragma: no cover - fallback
+        price = None
+    if price is None:
+        try:
+            hist = data.history(period="1d")
+            price = float(hist["Close"].iloc[-1])
+        except Exception:
+            price = None
+    return price
+
+
+def get_price(ticker: str) -> Dict[str, Any]:
+    """Return a JSON-serialisable dict with ticker price."""
+    ticker = ticker.upper()
+    price = _get_last_price(ticker)
+    if price is None:
+        raise ValueError(f"no price for ticker {ticker}")
+    return {"ticker": ticker, "price": float(price)}
+
+
+def get_analysis(ticker: str) -> Dict[str, Any]:
+    """Return basic metrics for ``ticker``.
+
+    Currently includes price and trailing P/E ratio if available.
+    """
+
+    ticker = ticker.upper()
+    data = yf.Ticker(ticker)
+    price = _get_last_price(ticker)
+    info = data.info or {}
+    pe = info.get("trailingPE")
+    if price is None:
+        raise ValueError(f"no price for ticker {ticker}")
+    result: Dict[str, Any] = {"ticker": ticker, "price": float(price)}
+    if pe is not None:
+        result["pe"] = float(pe)
+    return result
+

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+yfinance
+pytest

--- a/python-service/server.py
+++ b/python-service/server.py
@@ -1,7 +1,31 @@
-from fastapi import FastAPI, Query
+import logging
+
+from fastapi import FastAPI, Query, HTTPException
+
+from fetch_data import get_price, get_analysis
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
+
 @app.get("/price")
 def ticker_price(ticker: str = Query(..., min_length=1, max_length=5)):
-    return {"ticker": ticker, "price": 12}
+    """Return the latest price for a ticker."""
+    try:
+        return get_price(ticker)
+    except Exception as exc:  # pragma: no cover - logging only
+        logger.error("Failed to fetch price for %s: %s", ticker, exc)
+        raise HTTPException(status_code=404, detail="Ticker not found")
+
+
+@app.get("/analyze")
+def analyze(ticker: str = Query(..., min_length=1, max_length=5)):
+    """Return a basic analysis for a ticker."""
+    try:
+        return get_analysis(ticker)
+    except Exception as exc:  # pragma: no cover - logging only
+        logger.error("Failed to analyze %s: %s", ticker, exc)
+        raise HTTPException(status_code=404, detail="Ticker not found")
+

--- a/python-service/test_server.py
+++ b/python-service/test_server.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+import server
+
+
+def test_price_endpoint(monkeypatch):
+    def fake_price(ticker: str):
+        return {"ticker": ticker, "price": 123.45}
+
+    monkeypatch.setattr(server, "get_price", fake_price)
+    client = TestClient(server.app)
+
+    resp = client.get("/price", params={"ticker": "AAPL"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ticker": "AAPL", "price": 123.45}
+
+
+def test_analyze_endpoint(monkeypatch):
+    def fake_analysis(ticker: str):
+        return {"ticker": ticker, "price": 123.45, "pe": 20.0}
+
+    monkeypatch.setattr(server, "get_analysis", fake_analysis)
+    client = TestClient(server.app)
+
+    resp = client.get("/analyze", params={"ticker": "AAPL"})
+    assert resp.status_code == 200
+    assert resp.json()["pe"] == 20.0
+


### PR DESCRIPTION
## Summary
- Add FastAPI endpoints and yfinance-based data fetching for real stock prices and basic analysis
- Wire Go CLI commands to call Python service with configurable base URL
- Include unit tests, requirements, and expanded README usage instructions

## Testing
- `pytest python-service` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b0e7ae9d0c8327a4f995512d4064e4